### PR TITLE
TC-1068 Support snapshot in config.sh

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 ./configure --pkg-config=pkg-config \
           --enable-small \
-          --disable-shared \
           --enable-static \
+          --disable-shared \
           --disable-runtime-cpudetect \
-          --disable-swscale-alpha \
           --disable-autodetect \
           --disable-ffplay \
           --disable-ffprobe \
@@ -19,26 +18,32 @@
           --enable-avfilter \
           --enable-pthreads \
           --enable-network \
+          --enable-swscale \
+          --enable-swscale-alpha \
           --disable-avdevice \
-          --disable-swscale \
           --disable-postproc \
           --disable-everything \
           --enable-protocol=file \
           --enable-protocol=rtmp \
           --enable-filter=aresample \
+          --enable-filter=scale \
           --enable-decoder=h264 \
           --enable-decoder=pcm_alaw \
           --enable-decoder=pcm_mulaw \
           --enable-decoder=hevc \
           --enable-encoder=aac \
+          --enable-encoder=mjpeg \
           --enable-parser=h264 \
           --enable-parser=hevc \
+          --enable-parser=mjpeg \
           --enable-muxer=mp4 \
           --enable-muxer=flv \
           --enable-muxer=mpegts \
           --enable-muxer=rtsp \
           --enable-muxer=rtp \
           --enable-muxer=hevc \
+          --enable-muxer=image2 \
+          --enable-muxer=mjpeg \
           --enable-demuxer=mov \
           --enable-demuxer=flv \
           --enable-demuxer=mpegts \


### PR DESCRIPTION
snapshot cmd:
`ffmpeg -rtsp_transport tcp -i 'rtsp://admin:1234qwer!@192.168.11.191/unicast/c6/s1/live' -ss 00:00:00 -vframes 1 -f image2 -vcodec mjpeg -y out.jpg`

To support 'mjpeg' and 'image2', ffmpeg compile shoud open "--enable-swscale --enable-swscale-alpha --enable-filter=scale --enable-encoder=mjpeg --enable-parser=mjpeg --enable-muxer=mjpeg --enable-muxer=image2", and then the size of ffmpeg exe will larger 900kB than before.