### PR TITLE
TV-5200  Add speed download

### DIFF
--- a/fftools/ffmpeg_opt.c
+++ b/fftools/ffmpeg_opt.c
@@ -1685,7 +1685,7 @@ static OutputStream *new_output_stream(OptionsContext *o, AVFormatContext *oc, e
             tag = AV_RL32(codec_tag);
 
         av_log(NULL, AV_LOG_INFO, "auto_hvc1 = %d,  tag is %s\n", auto_hvc1, codec_tag);
-        if (!auto_hvc1 || strcmp(codec_tag, "hvc1") || \
+        if (!auto_hvc1 || strncmp(codec_tag, "hvc1", 4) || \
            (input_streams[source_index] && input_streams[source_index]->dec && input_streams[source_index]->dec->id == AV_CODEC_ID_H265)) {
             av_log(NULL, AV_LOG_INFO, "set origin tag, %s\n", codec_tag);
             ost->st->codecpar->codec_tag =


### PR DESCRIPTION
If we add `auto_hvc1` option, then the option  `-vtag hvc1` will only has effect on h265 video file,  this will ignore the `auto_hvc1` option if the original file is h264.
Otherwise we need to ffprobe the video file first to recognize the video type of h264 or h265, then use ffmpeg to record the video.